### PR TITLE
docker: add build of debs for Debian 12 Bookworm

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -65,6 +65,20 @@ jobs:
           name: debs-debian11
           path: |
             deb-build/DEBS/all/*.deb
+  build-debian12-debs:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build a Debian 12 Package
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          ./docker/debs/build-and-install-debs.sh deb12 docker/debs/Debian_12/Debian12.dockerfile
+      - name: Archive DEBs
+        uses: actions/upload-artifact@v3
+        with:
+          name: debs-debian12
+          path: |
+            deb-build/DEBS/all/*.deb
   create-release:
     name: Build the release and create a GitHub release
     runs-on: ubuntu-20.04
@@ -73,6 +87,7 @@ jobs:
       build-fedora34-rpms,
       build-debian10-debs,
       build-debian11-debs,
+      build-debian12-debs,
     ]
     steps:
       - uses: actions/checkout@v2
@@ -88,4 +103,5 @@ jobs:
             artifacts/rpms-centos8/*.rpm
             artifacts/debs-debian10/*.deb
             artifacts/debs-debian11/*.deb
+            artifacts/debs-debian12/*.deb
             artifacts/rpms-fedora-34/*.rpm

--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,9 @@ test-debian10: ## Executes the testscript for testing cobbler in a docker contai
 test-debian11: ## Executes the testscript for testing cobbler in a docker container on Debian 11.
 	./docker/debs/build-and-install-debs.sh deb11 docker/debs/Debian_11/Debian11.dockerfile
 
+test-debian12: ## Executes the testscript for testing cobbler in a docker container on Debian 12.
+	./docker/debs/build-and-install-debs.sh deb12 docker/debs/Debian_12/Debian12.dockerfile
+
 system-test: ## Runs the system tests
 	$(MAKE) -C system-tests
 

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -103,7 +103,7 @@
 %define system_release_pkg base-files
 
 # Debian 11 moved to the C implementation of createrepo
-%if 0%{?debian} == 11
+%if 0%{?debian} >= 11
 %define createrepo_pkg createrepo-c
 %endif
 

--- a/docker/debs/Debian_12/Debian12.dockerfile
+++ b/docker/debs/Debian_12/Debian12.dockerfile
@@ -1,0 +1,81 @@
+# vim: ft=dockerfile
+
+FROM debian:12
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# TERM=screen is fairly neutral and works with xterm for example, for others
+# you might need to pass -e TERM=<terminal>, like rxvt-unicode.
+ENV TERM screen
+ENV OSCODENAME bookworm
+
+# Add repo for debbuild and install all packages required
+# hadolint ignore=DL3008,DL3015,DL4006
+RUN apt-get update -qq && \
+    apt-get install -qqy gnupg curl && \
+    /bin/sh -c "echo 'deb http://download.opensuse.org/repositories/Debian:/debbuild/Debian_12/ /' > /etc/apt/sources.list.d/debbuild.list" && \
+    curl -sL http://download.opensuse.org/repositories/Debian:/debbuild/Debian_12/Release.key | apt-key add - && \
+    apt-get update -qq && \
+    apt-get install -qqy \
+    debbuild \
+    debbuild-macros \
+    wget \
+    pycodestyle \
+    pyflakes3 \
+    python3-cheetah  \
+    python3-coverage \
+    python3-wheel   \
+    python3-distro \
+    python3-distutils \
+    python3-dnspython \
+    python3-dns  \
+    python3-dnsq  \
+    python3-magic  \
+    python3-ldap \
+    python3-netaddr \
+    python3-pip \
+    python3-pycodestyle \
+    python3-pytest \
+    python3-setuptools \
+    python3-simplejson  \
+    python3-sphinx \
+    python3-tz \
+    python3-yaml \
+    python3-schema \
+    liblocale-gettext-perl \
+    lsb-release \
+    xz-utils \
+    bzip2 \
+    dpkg-dev \
+    tftpd-hpa \
+    createrepo-c \
+    rsync \
+    xorriso\
+    fence-agents\
+    fakeroot \
+    patch \
+    pax \
+    git \
+    hardlink \
+    apache2 \
+    libapache2-mod-wsgi-py3 \
+    iproute2 \
+    systemd \
+    systemd-sysv \
+    supervisor && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Make /bin/sh point to bash, not dash
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN echo "dash dash/sh boolean false" | debconf-set-selections && \
+    dpkg-reconfigure dash
+
+COPY ./docker/debs/Debian_12/supervisord/supervisord.conf /etc/supervisord.conf
+COPY ./docker/debs/Debian_12/supervisord/conf.d /etc/supervisord/conf.d
+
+COPY . /usr/src/cobbler
+WORKDIR /usr/src/cobbler
+
+VOLUME /usr/src/cobbler/deb-build
+
+CMD ["/bin/bash", "-c", "make debs"]

--- a/docker/debs/Debian_12/supervisord/conf.d/apache2.conf
+++ b/docker/debs/Debian_12/supervisord/conf.d/apache2.conf
@@ -1,0 +1,10 @@
+[program:apache2]
+command=/usr/sbin/apache2 -D FOREGROUND
+redirect_stderr=true
+environment=
+    APACHE_RUN_USER=www-data,
+    APACHE_RUN_GROUP=www-data,
+    APACHE_PID_FILE=/var/run/apache2/apache2.pid,
+    APACHE_RUN_DIR=/var/run/apache2,
+    APACHE_LOCK_DIR=/var/lock/apache2,
+    APACHE_LOG_DIR=/var/log/apache2,

--- a/docker/debs/Debian_12/supervisord/conf.d/cobblerd.conf
+++ b/docker/debs/Debian_12/supervisord/conf.d/cobblerd.conf
@@ -1,0 +1,3 @@
+[program:cobblerd]
+command=cobblerd -F
+redirect_stderr=true

--- a/docker/debs/Debian_12/supervisord/conf.d/dhcpd.conf
+++ b/docker/debs/Debian_12/supervisord/conf.d/dhcpd.conf
@@ -1,0 +1,3 @@
+[program:dhcpd]
+command=/usr/lib/dhcp/dhcpd -4 start
+redirect_stderr=true

--- a/docker/debs/Debian_12/supervisord/conf.d/slapd.conf
+++ b/docker/debs/Debian_12/supervisord/conf.d/slapd.conf
@@ -1,0 +1,4 @@
+[program:slapd]
+command=/usr/sbin/slapd -u ldap -h "ldap:/// ldaps:/// ldapi:///" -f /test_dir/tests/test_data/slapd.conf
+redirect_stderr=true
+autostart=false

--- a/docker/debs/Debian_12/supervisord/conf.d/tftpd.conf
+++ b/docker/debs/Debian_12/supervisord/conf.d/tftpd.conf
@@ -1,0 +1,3 @@
+[program:tftpd]
+command=/usr/sbin/in.tftpd -L -u root -s /srv/tftpboot
+redirect_stderr=true

--- a/docker/debs/Debian_12/supervisord/supervisord.conf
+++ b/docker/debs/Debian_12/supervisord/supervisord.conf
@@ -1,0 +1,19 @@
+[supervisord]
+loglevel=debug
+logfile=/var/log/supervisor/supervisor.log
+user=root
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[unix_http_server]
+file=/run/supervisord.sock
+
+[inet_http_server]
+port=9001
+
+[include]
+files=/etc/supervisord/conf.d/*.conf
+
+[supervisorctl]
+serverurl=unix:///run/supervisord.sock

--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -104,6 +104,7 @@ However we provide docker files for
 - CentOS 8
 - Debian 10 Buster
 - Debian 11 Bullseye
+- Debian 12 Bookworm
 
 which will give you packages which will work better then building from source yourself.
 
@@ -116,6 +117,7 @@ To build the packages you to need to execute the following in the root folder of
 - CentOS 8: ``./docker/rpms/build-and-install-rpms.sh el8 docker/rpms/CentOS_8/CentOS8.dockerfile``
 - Debian 10: ``./docker/debs/build-and-install-debs.sh deb10 docker/debs/Debian_10/Debian10.dockerfile``
 - Debian 11: ``./docker/debs/build-and-install-debs.sh deb11 docker/debs/Debian_11/Debian11.dockerfile``
+- Debian 12: ``./docker/debs/build-and-install-debs.sh deb12 docker/debs/Debian_12/Debian12.dockerfile``
 
 After executing the scripts you should have one folder owned by ``root`` which was created during the build. It is
 either called ``rpm-build`` or ``deb-build``. In these directories you should find the built packages. They are


### PR DESCRIPTION
This commit adds a Dockerfile to build the debs for Debian 12.

Update the installation guide to provide the build and install command for Debian 12. Also add Debian 12 to the Makefile and GH Action jobs